### PR TITLE
Ignore bower_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Ignore .DS_store file
 .DS_Store
+
+# Ignore bower components
+source/bower_components

--- a/config.rb
+++ b/config.rb
@@ -5,7 +5,7 @@
 compass_config do |config|
   # Require any additional compass plugins here.
   config.add_import_path "bower_components/foundation/scss"
-  
+
   # Set this to the root of your project when deployed:
   config.http_path = "/"
   config.css_dir = "stylesheets"
@@ -87,6 +87,8 @@ set :js_dir, 'javascripts'
 set :images_dir, 'images'
 
 activate :livereload
+
+ignore "bower_components/*"
 
 # Build-specific configuration
 configure :build do


### PR DESCRIPTION
I've just started to use this project (thank you!), and correct me if I'm wrong, but the bower_components directory doesn't need to be included in the server and build phases.
